### PR TITLE
Measuring time for performance tweaking.

### DIFF
--- a/src/config_rpm_maker/configrpmmaker.py
+++ b/src/config_rpm_maker/configrpmmaker.py
@@ -120,7 +120,6 @@ Please fix the issues and trigger the RPM creation with a dummy commit.
         self._create_logger()
         self.work_dir = None
 
-    @measure_execution_time
     def __build_error_msg_and_move_to_public_access(self, revision):
         err_url = config.get('error_log_url', DEFAULT_ERROR_LOG_URL)
         error_msg = self.ERROR_MSG % (err_url, revision)
@@ -208,7 +207,6 @@ Please fix the issues and trigger the RPM creation with a dummy commit.
             LOGGER.debug('Updating configviewer data for host "%s"', host)
             move(temp_path, dest_path)
 
-    @measure_execution_time
     def _build_hosts(self, hosts):
         if not hosts:
             LOGGER.warn('Trying to build rpms for hosts, but no hosts given!')

--- a/src/config_rpm_maker/exitprogram.py
+++ b/src/config_rpm_maker/exitprogram.py
@@ -23,6 +23,7 @@ from time import time, strftime
 
 from config_rpm_maker.config import DEFAULT_DATE_FORMAT
 from config_rpm_maker.returncodes import RETURN_CODE_SUCCESS
+from config_rpm_maker.profiler import log_execution_time_summaries
 
 LOGGER = getLogger(__name__)
 
@@ -45,6 +46,8 @@ def get_timestamp_from_start():
 
 def exit_program(message, return_code):
     """ Logs the given message and exits with given return code. """
+
+    log_execution_time_summaries(LOGGER.debug)
 
     timestamp_from_start = get_timestamp_from_start()
     if timestamp_from_start is not None:

--- a/src/config_rpm_maker/hostrpmbuilder.py
+++ b/src/config_rpm_maker/hostrpmbuilder.py
@@ -164,7 +164,6 @@ class HostRpmBuilder(object):
         revision_file_path = os.path.join(self.config_viewer_host_dir, self.hostname + '.rev')
         self._write_file(revision_file_path, self.revision)
 
-    @measure_execution_time
     def _find_rpms(self):
         result = []
         for root, dirs, files in os.walk(os.path.join(self.rpm_build_dir, 'RPMS')):
@@ -229,7 +228,6 @@ class HostRpmBuilder(object):
         shutil.copytree(self.host_config_dir, self.config_viewer_host_dir, symlinks=True)
         shutil.copytree(self.variables_dir, os.path.join(self.config_viewer_host_dir, 'VARIABLES'))
 
-    @measure_execution_time
     def _generate_patch_info(self):
         variables = filter(lambda name: name != 'SVNLOG' and name != 'OVERLAYING', os.listdir(self.variables_dir))
         variables = sorted(variables)
@@ -243,12 +241,10 @@ class HostRpmBuilder(object):
         self._write_file(os.path.join(self.variables_dir, 'FQDN'), fqdn)
         self._write_file(os.path.join(self.variables_dir, 'ALIASES'), aliases)
 
-    @measure_execution_time
     def _save_segment_variables(self):
         for segment in ALL_SEGEMENTS:
             self._write_file(os.path.join(self.variables_dir, segment.get_variable_name()), segment.get(self.hostname)[-1])
 
-    @measure_execution_time
     def _save_file_list(self):
         f = open(os.path.join(self.work_dir, 'filelist.' + self.hostname), 'w')
         try:
@@ -318,7 +314,6 @@ Change set:
          "\n   ".join([path['action'] + ' ' + path['path'] for path in log['changed_paths']]),
          log['message'])
 
-    @measure_execution_time
     def _export_spec_file(self):
         svn_service = self.svn_service_queue.get()
         try:

--- a/src/config_rpm_maker/svnservice.py
+++ b/src/config_rpm_maker/svnservice.py
@@ -22,6 +22,7 @@ from logging import getLogger
 from config_rpm_maker.config import DEFAULT_HOST_NAME_ENCODING
 from config_rpm_maker.logutils import log_elements_of_list
 from config_rpm_maker.exceptions import BaseConfigRpmMakerException
+from config_rpm_maker.profiler import measure_execution_time
 
 LOGGER = getLogger(__name__)
 
@@ -49,6 +50,7 @@ class SvnService(object):
             LOGGER.debug('Setting default password for subversion client.')
             self.client.set_default_password(password)
 
+    @measure_execution_time
     def get_change_set(self, revision):
         try:
             logs = self.client.log(self.config_url, self._rev(revision), self._rev(revision), discover_changed_paths=True)
@@ -62,6 +64,7 @@ class SvnService(object):
         log_elements_of_list(LOGGER.debug, 'The commit change set contained %s changed path(s).', changed_paths)
         return changed_paths
 
+    @measure_execution_time
     def get_hosts(self, revision):
         url = self.config_url + '/host'
 
@@ -73,6 +76,7 @@ class SvnService(object):
         repos_paths = [item[0].repos_path.encode(DEFAULT_HOST_NAME_ENCODING) for item in items]
         return [os.path.basename(repos_path) for repos_path in repos_paths]
 
+    @measure_execution_time
     def export(self, svn_path, target_dir, revision):
         url = self._get_url(svn_path)
 
@@ -86,6 +90,7 @@ class SvnService(object):
         normalized_paths = filter(lambda path: path != '', normalized_paths)
         return [(svn_path, path) for path in normalized_paths]
 
+    @measure_execution_time
     def log(self, svn_path, revision, limit=0):
         url = self._get_url(svn_path)
         return self.client.log(url, pysvn.Revision(pysvn.opt_revision_kind.head), self._rev(revision), discover_changed_paths=True, limit=limit)


### PR DESCRIPTION
This changes the profiling mechanism and adds some debug logging.

The sys log will then show something like this:

```
[DEBUG] Execution times summary (keep in mind thread_count was set to 4):
[DEBUG]       1 times with average  0.01s = sum  0.01s : ConfigRpmMaker._upload_rpms
[DEBUG]       3 times with average  2.37s = sum   7.1s : HostRpmBuilder._build_rpm_using_rpmbuild
[DEBUG]       3 times with average  0.06s = sum  0.18s : HostRpmBuilder._copy_files_for_config_viewer
[DEBUG]       3 times with average  0.06s = sum  0.17s : HostRpmBuilder._filter_tokens_in_rpm_sources
[DEBUG]       3 times with average  1.84s = sum  5.51s : HostRpmBuilder._save_network_variables
[DEBUG]       3 times with average  0.02s = sum  0.06s : HostRpmBuilder._tar_sources
[DEBUG]      15 times with average  0.01s = sum  0.09s : SvnService.export
[DEBUG]       1 times with average  0.02s = sum  0.02s : SvnService.get_change_set
[DEBUG]       1 times with average  0.01s = sum  0.01s : SvnService.get_hosts
[DEBUG]       8 times with average  0.01s = sum  0.03s : SvnService.log
[ INFO] Elapsed time: 5.58s
```
