### PR TITLE
make documentation more specific regarding location of specfile template...

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -22,7 +22,7 @@ Please have a look at the [example configuration file.](https://github.com/yadt/
 | custom_dns_searchlist   | []               | Helps to resolve the hosts. If your organisation has hosts in "*.datacenter.intern" and in "*.organisation.intern" you can set this to ['datacenter.intern', 'organisation.intern']
 | error_log_dir           | ""               | The directory from where your config viewer will serve the error files.
 | error_log_url           | ""               | The url under which the config viewer will be accessible.
-| path_to_spec_file       | default.spec     | The path where to find the template spec file for your configuration rpms.
+| path_to_spec_file       | default.spec     | The path within the configuration subversion repository where to find the template spec file for your configuration rpms.
 | repo_packages_regex     | ^yadt-.*-repos?$ | This filter will be applied when writing the dependencies into the rpm.
 | rpm_upload_chunk_size   | 10               | Building the configuration rpms will happen in chunks. The number you specify here will define how many rpms will be built at the same time.
 | rpm_upload_cmd          |                  | The command which will be used to upload the rpms. The command will get the list rpms to build as arguments. How many rpms will be given is defined via 'rpm_upload_chunk_size'. If this is not defined no command will be executed.


### PR DESCRIPTION
needed some time to understand that template file is taken from subversion not from local filesystem. Wanted to make live easier for others, too.
