### PR TITLE
Fixed Bug: config-rpm-maker throws exception if config path is nonexistent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "2.7"
 
 before_script:
+  - sudo apt-get update
   - sudo apt-get install python-svn 
   - ln -s /usr/lib/python2.7/dist-packages/pysvn $VIRTUAL_ENV/lib/python2.7/site-packages/
   - sudo apt-get install rpm python-rpm

--- a/src/config_rpm_maker/configrpmmaker.py
+++ b/src/config_rpm_maker/configrpmmaker.py
@@ -136,6 +136,9 @@ Please fix the issues and trigger the RPM creation with a dummy commit.
         self.logger.info("Starting with revision %s", self.revision)
         try:
             changed_paths = self.svn_service.get_changed_paths(self.revision)
+            if not changed_paths:
+                LOGGER.info("No rpm(s) built. No change in configuration directory.")
+                return
             available_hosts = self.svn_service.get_hosts(self.revision)
 
             affected_hosts = list(self._get_affected_hosts(changed_paths, available_hosts))

--- a/src/config_rpm_maker/svnservice.py
+++ b/src/config_rpm_maker/svnservice.py
@@ -75,7 +75,7 @@ class SvnService(object):
         return logs
 
     def get_changed_paths_with_action(self, revision):
-        """ Returns a list of all paths from the change set which were marked with action "delete" """
+        """ Returns a list of all (path, action) tuples from the change set """
 
         log_entries = self.get_logs_for_revision(revision)
 

--- a/src/config_rpm_maker/svnservice.py
+++ b/src/config_rpm_maker/svnservice.py
@@ -66,7 +66,7 @@ class SvnService(object):
         """ Returns the logs for the given revision of the repository at the config_url """
 
         try:
-            logs = self.client.log(self.config_url, self._rev(revision), self._rev(revision),
+            logs = self.client.log(self.base_url, self._rev(revision), self._rev(revision),
                                    discover_changed_paths=True)
         except Exception as e:
             LOGGER.error('Retrieving change set information for revision "%s" in repository "%s" failed.',

--- a/src/config_rpm_maker/svnservice.py
+++ b/src/config_rpm_maker/svnservice.py
@@ -79,10 +79,13 @@ class SvnService(object):
 
         log_entries = self.get_logs_for_revision(revision)
 
-        start_pos = len(self.path_to_config + '/')
+        path_to_config_slash = self.path_to_config + '/'
+        start_pos = len(path_to_config_slash)
         action_and_path = []
         for info in log_entries:
             for path_obj in info.changed_paths:
+                if not path_obj.path.startswith(path_to_config_slash):
+                    continue
                 changed_path = path_obj.path[start_pos:]
                 action_and_path.append((changed_path, path_obj.action))
 

--- a/test/integrationtests/configrpmmaker_integration_test.py
+++ b/test/integrationtests/configrpmmaker_integration_test.py
@@ -27,13 +27,11 @@ from config_rpm_maker.configrpmmaker import (CouldNotBuildSomeRpmsException,
                                              ConfigRpmMaker,
                                              configuration)
 from config_rpm_maker.configuration.properties import (is_no_clean_up_enabled,
-                                                       get_svn_path_to_config,
                                                        get_config_rpm_prefix,
                                                        get_temporary_directory,
                                                        get_rpm_upload_command)
 from config_rpm_maker.configuration import build_config_viewer_host_directory
 from config_rpm_maker.segment import All, Typ
-from config_rpm_maker.svnservice import SvnService
 
 EXECUTION_ERROR_MESSAGE = """Execution of "{command_with_arguments}" failed. Error code was {error_code}
 stdout was: "{stdout}"
@@ -195,11 +193,6 @@ class ConfigRpmMakerIntegrationTest(IntegrationTest):
         self.assert_path_does_not_exist(build_config_viewer_host_directory('devweb01', revision='2'))
         self.assert_path_does_not_exist(build_config_viewer_host_directory('tuvweb01', revision='2'))
         self.assert_path_does_not_exist(build_config_viewer_host_directory('berweb01', revision='2'))
-
-    def _given_config_rpm_maker(self, revision='2'):
-        svn_service = SvnService(base_url=self.repo_url, path_to_config=get_svn_path_to_config())
-
-        return ConfigRpmMaker(revision, svn_service)
 
     def assertRpm(self, hostname, rpms, requires=None, provides=None, files=None, symlinks=None, exhaustive=False):
         path = None

--- a/test/integrationtests/configrpmmaker_integration_test.py
+++ b/test/integrationtests/configrpmmaker_integration_test.py
@@ -19,7 +19,7 @@ import subprocess
 import rpm
 
 from integration_test_support import (IntegrationTest,
-                                      IntegrationTestWithNonConfigCommitAndNoConfig,
+                                      IntegrationTestWithNonConfigCommitAndNoConfigDir,
                                       IntegrationTestException)
 
 from config_rpm_maker.configrpmmaker import (CouldNotBuildSomeRpmsException,
@@ -39,8 +39,19 @@ stderr was: "{stderr}"
 """
 
 
-class ConfigRpmMakerIntegrationTestWithNonConfigCommitAndNoConfig(IntegrationTestWithNonConfigCommitAndNoConfig):
-    def test_build_should_not_fail_on_non_config_commit_with_no_config(self):
+class ConfigRpmMakerIntegrationTestWithNonConfigCommitAndNoConfig(IntegrationTestWithNonConfigCommitAndNoConfigDir):
+    def test_no_build_fail_on_non_config_commit_with_same_prefix_length(self):
+        # "/XXXXXX" has the same length as the configpath prefix "/config".
+        if subprocess.call('svn mkdir -q -m mkdir --parents  %s/XXXXXX/host/devweb01/' % self.repo_url, shell=True):
+            raise IntegrationTestException('Could not import test data.')
+        config_rpm_maker = self._given_config_rpm_maker(revision='1')
+        rpms = config_rpm_maker.build()
+        self.assertEqual(rpms, None)
+
+    def test_no_build_fail_on_non_config_commit_with_path_shorter_than_prefix(self):
+        # The commit path "/X/Y" is shorter than the configpath prefix "/config".
+        if subprocess.call('svn mkdir -q -m mkdir --parents  %s/X/Y/' % self.repo_url, shell=True):
+            raise IntegrationTestException('Could not import test data.')
         config_rpm_maker = self._given_config_rpm_maker(revision='1')
         rpms = config_rpm_maker.build()
         self.assertEqual(rpms, None)

--- a/test/integrationtests/configrpmmaker_integration_test.py
+++ b/test/integrationtests/configrpmmaker_integration_test.py
@@ -187,10 +187,10 @@ class ConfigRpmMakerIntegrationTest(IntegrationTest):
         self.assert_path_does_not_exist(build_config_viewer_host_directory('tuvweb01', revision='2'))
         self.assert_path_does_not_exist(build_config_viewer_host_directory('berweb01', revision='2'))
 
-    def _given_config_rpm_maker(self):
+    def _given_config_rpm_maker(self, revision='2'):
         svn_service = SvnService(base_url=self.repo_url, path_to_config=get_svn_path_to_config())
 
-        return ConfigRpmMaker('2', svn_service)
+        return ConfigRpmMaker(revision, svn_service)
 
     def assertRpm(self, hostname, rpms, requires=None, provides=None, files=None, symlinks=None, exhaustive=False):
         path = None

--- a/test/integrationtests/configrpmmaker_integration_test.py
+++ b/test/integrationtests/configrpmmaker_integration_test.py
@@ -18,7 +18,9 @@ import os
 import subprocess
 import rpm
 
-from integration_test_support import IntegrationTest, IntegrationTestException
+from integration_test_support import (IntegrationTest,
+                                      IntegrationTestWithNonConfigCommitAndNoConfig,
+                                      IntegrationTestException)
 
 from config_rpm_maker.configrpmmaker import (CouldNotBuildSomeRpmsException,
                                              CouldNotUploadRpmsException,
@@ -37,6 +39,13 @@ EXECUTION_ERROR_MESSAGE = """Execution of "{command_with_arguments}" failed. Err
 stdout was: "{stdout}"
 stderr was: "{stderr}"
 """
+
+
+class ConfigRpmMakerIntegrationTestWithNonConfigCommitAndNoConfig(IntegrationTestWithNonConfigCommitAndNoConfig):
+    def test_build_should_not_fail_on_non_config_commit_with_no_config(self):
+        config_rpm_maker = self._given_config_rpm_maker(revision='1')
+        rpms = config_rpm_maker.build()
+        self.assertEqual(rpms, None)
 
 
 class ConfigRpmMakerIntegrationTest(IntegrationTest):

--- a/test/integrationtests/integration_test_support.py
+++ b/test/integrationtests/integration_test_support.py
@@ -78,6 +78,11 @@ class IntegrationTest(unittest.TestCase):
 
         makedirs(self.repository_directory)
 
+    def _given_config_rpm_maker(self, revision='2'):
+        svn_service = SvnService(base_url=self.repo_url, path_to_config=get_svn_path_to_config())
+
+        return ConfigRpmMaker(revision, svn_service)
+
     def write_revision_file_for_hostname(self, hostname, revision):
 
         config_viewer_host_directory = build_config_viewer_host_directory(hostname)

--- a/test/integrationtests/integration_test_support.py
+++ b/test/integrationtests/integration_test_support.py
@@ -43,15 +43,10 @@ class IntegrationTestException(Exception):
 class IntegrationTest(unittest.TestCase):
 
     def setUp(self):
-
         configuration.set_property(is_no_clean_up_enabled, KEEP_TEMPORARY_DIRECTORY)
-
         temporary_directory = get_temporary_directory()
-
         self.clean_up_temporary_directory(temporary_directory)
-
         self.temporary_directory = temporary_directory
-
         self.create_svn_repo()
 
     def tearDown(self):

--- a/test/integrationtests/integration_test_support.py
+++ b/test/integrationtests/integration_test_support.py
@@ -29,6 +29,7 @@ from config_rpm_maker.svnservice import SvnService
 from config_rpm_maker.configuration.properties import (is_no_clean_up_enabled,
                                                        get_temporary_directory,
                                                        get_svn_path_to_config)
+from config_rpm_maker.configrpmmaker import ConfigRpmMaker
 from config_rpm_maker.configuration import build_config_viewer_host_directory
 
 # This constant exists for debugging purposes.

--- a/test/integrationtests/integration_test_support.py
+++ b/test/integrationtests/integration_test_support.py
@@ -162,12 +162,10 @@ Expected: "{expected}"
             rmtree(temporary_directory)
 
 
-class IntegrationTestWithNonConfigCommitAndNoConfig(IntegrationTest):
+class IntegrationTestWithNonConfigCommitAndNoConfigDir(IntegrationTest):
     def setUp(self):
         configuration.set_property(is_no_clean_up_enabled, KEEP_TEMPORARY_DIRECTORY)
         temporary_directory = get_temporary_directory()
         self.clean_up_temporary_directory(temporary_directory)
         self.temporary_directory = temporary_directory
         self.create_empty_svn_repo()
-        if subprocess.call('svn mkdir -q -m mkdir --parents  %s/XXXXXX/host/devweb01/' % self.repo_url, shell=True):
-            raise IntegrationTestException('Could not import test data.')

--- a/test/integrationtests/integration_test_support.py
+++ b/test/integrationtests/integration_test_support.py
@@ -154,3 +154,14 @@ Expected: "{expected}"
     def clean_up_temporary_directory(self, temporary_directory):
         if not KEEP_TEMPORARY_DIRECTORY and exists(temporary_directory):
             rmtree(temporary_directory)
+
+
+class IntegrationTestWithNonConfigCommitAndNoConfig(IntegrationTest):
+    def setUp(self):
+        configuration.set_property(is_no_clean_up_enabled, KEEP_TEMPORARY_DIRECTORY)
+        temporary_directory = get_temporary_directory()
+        self.clean_up_temporary_directory(temporary_directory)
+        self.temporary_directory = temporary_directory
+        self.create_empty_svn_repo()
+        if subprocess.call('svn mkdir -q -m mkdir --parents  %s/XXXXXX/host/devweb01/' % self.repo_url, shell=True):
+            raise IntegrationTestException('Could not import test data.')

--- a/test/integrationtests/integration_test_support.py
+++ b/test/integrationtests/integration_test_support.py
@@ -53,7 +53,7 @@ class IntegrationTest(unittest.TestCase):
 
         self.clean_up_temporary_directory(self.temporary_directory)
 
-    def create_svn_repo(self):
+    def create_empty_svn_repo(self):
         self._create_repository_directory()
 
         if subprocess.call('svnadmin create %s' % self.repository_directory, shell=True):
@@ -61,6 +61,8 @@ class IntegrationTest(unittest.TestCase):
 
         self.repo_url = 'file://%s' % self.repository_directory
 
+    def create_svn_repo(self):
+        self.create_empty_svn_repo()
         if subprocess.call('svn import -q -m import testdata/svn_repo %s' % self.repo_url, shell=True):
             raise IntegrationTestException('Could not import test data.')
 

--- a/test/unittests/svnservice_tests.py
+++ b/test/unittests/svnservice_tests.py
@@ -110,6 +110,33 @@ class GetChangedPathsWithActionTests(TestCase):
 
         self.assertEqual([('', 'A'), ('spam.egg', 'A')], actual)
 
+    def test_should_not_include_files_outside_config_directory(self):
+
+        mock_svn_service = Mock(SvnService)
+        mock_svn_service.config_url = 'svn://url/for/configuration/repository'
+        mock_svn_service.path_to_config = '/config'
+        mock_svn_service.client = Mock()
+        mock_info = Mock()
+
+        mock_path_object_1 = Mock()
+        mock_path_object_1.path = '/config/foo'
+        mock_path_object_1.action = 'A'
+
+        mock_path_object_2 = Mock()
+        mock_path_object_2.path = '/XXXXXX/bar'
+        mock_path_object_2.action = 'A'
+
+        mock_path_object_3 = Mock()
+        mock_path_object_3.path = '/XXX/foobar'
+        mock_path_object_3.action = 'A'
+
+        mock_info.changed_paths = [mock_path_object_1, mock_path_object_2, mock_path_object_3]
+        mock_svn_service.get_logs_for_revision.return_value = [mock_info]
+
+        actual = SvnService.get_changed_paths_with_action(mock_svn_service, '1980')
+
+        self.assertEqual([('foo', 'A')], actual)
+
     def test_should_return_list_with_tuples_including_one_tuple_which_has_a_delete_action(self):
 
         mock_svn_service = Mock(SvnService)

--- a/test/unittests/svnservice_tests.py
+++ b/test/unittests/svnservice_tests.py
@@ -51,7 +51,8 @@ class GetLogsForRevision(TestCase):
     def test_should_raise_exception_when_pysvn_client_fails_to_log(self):
 
         mock_svn_service = Mock(SvnService)
-        mock_svn_service.config_url = 'svn://url/for/configuration/repository'
+        mock_svn_service.config_url = 'svn://url/for/configuration/repository/config'
+        mock_svn_service.base_url = 'svn://url/for/configuration/repository'
         mock_svn_service.path_to_config = '/config'
         mock_svn_service.client = Mock()
         mock_svn_service.client.log.side_effect = Exception("Aaarrrgggghh...")
@@ -60,7 +61,7 @@ class GetLogsForRevision(TestCase):
 
     def test_should_return_logs_for_revision(self):
         mock_svn_service = Mock(SvnService)
-        mock_svn_service.config_url = 'svn://url/for/configuration/repository'
+        mock_svn_service.base_url = 'svn://url/for/configuration/repository'
         mock_svn_service.path_to_config = '/config'
         mock_svn_service.client = Mock()
         mock_logs = Mock()


### PR DESCRIPTION
The config-rpm-maker throws an exception on any commit, if the $CONFIG_PATH/host/ Path does not exist. 
Additionally there is a chance of new RPM builds if a committed path contains a a prefix with the same length as $CONFIG_PATH/ and one of the Overlays (all, loc, ...)

To fix that, we first check all changed paths for  $CONFIG_PATH/ at the beginning and return before testing for hosts if the changed paths list is empty.
